### PR TITLE
Add --limit to clustering (KMeans/HDBSCAN)

### DIFF
--- a/docs/cli/clustering.md
+++ b/docs/cli/clustering.md
@@ -22,6 +22,7 @@ MiniBatchKMeans is recommended for large datasets. It scales well and produces c
 | `--embed-batch-size` | INTEGER | 32 | Batch size for embedding |
 | `--mb-batch-size` | INTEGER | 4096 | MiniBatch size for KMeans |
 | `--chunk-size` | INTEGER | 5000 | Chunk size for streaming |
+| `--limit` | INTEGER | None | Limit number of queries to cluster |
 | `--description` | TEXT | None | Optional run description |
 
 #### Examples
@@ -46,6 +47,12 @@ uv run lmsys cluster kmeans --n-clusters 50 --use-chroma \
   --embed-batch-size 64 --mb-batch-size 8192 --chunk-size 10000
 ```
 
+Limit queries to speed up experimentation (e.g., first 5000 rows):
+
+```bash
+uv run lmsys cluster kmeans --n-clusters 200 --limit 5000
+```
+
 ### HDBSCAN
 
 ```bash
@@ -64,6 +71,7 @@ HDBSCAN finds natural clusters based on density. It excludes noise points and do
 | `--chunk-size` | INTEGER | 5000 | Chunk size for streaming |
 | `--min-cluster-size` | INTEGER | 15 | Minimum cluster size |
 | `--min-samples` | INTEGER | 5 | Minimum samples for core point |
+| `--limit` | INTEGER | None | Limit number of queries to cluster |
 | `--description` | TEXT | None | Optional run description |
 
 #### Examples
@@ -79,6 +87,12 @@ Adjust density parameters:
 ```bash
 uv run lmsys cluster hdbscan --use-chroma \
   --min-cluster-size 20 --min-samples 10
+```
+
+Limit queries for quicker runs (e.g., first 8000 rows):
+
+```bash
+uv run lmsys cluster hdbscan --limit 8000
 ```
 
 ## Understanding Run IDs

--- a/src/lmsys_query_analysis/cli/commands/clustering.py
+++ b/src/lmsys_query_analysis/cli/commands/clustering.py
@@ -25,6 +25,7 @@ def cluster_kmeans(
     mb_batch_size: int = typer.Option(4096, help="MiniBatchKMeans batch_size"),
     use_chroma: bool = typer.Option(False, help="Enable ChromaDB"),
     chroma_path: str = chroma_path_option,
+    limit: int = typer.Option(None, help="Limit number of queries to cluster"),
 ):
     """Run MiniBatchKMeans clustering."""
     model, provider = parse_embedding_model(embedding_model)
@@ -32,7 +33,7 @@ def cluster_kmeans(
     chroma = create_chroma_client(chroma_path, model, provider) if use_chroma else None
     
     console.print(
-        f"[cyan]Running clustering: algo=kmeans, n_clusters={n_clusters}, model={model}, provider={provider}, use_chroma={use_chroma}[/cyan]"
+        f"[cyan]Running clustering: algo=kmeans, n_clusters={n_clusters}, model={model}, provider={provider}, use_chroma={use_chroma}, limit={limit}[/cyan]"
     )
     
     run_id = run_kmeans_clustering(
@@ -45,6 +46,7 @@ def cluster_kmeans(
         mb_batch_size=mb_batch_size,
         embedding_provider=provider,
         chroma=chroma,
+        max_queries=limit,
     )
     
     if run_id:
@@ -76,6 +78,7 @@ def cluster_hdbscan(
     ),
     use_chroma: bool = typer.Option(False, help="Enable ChromaDB"),
     chroma_path: str = chroma_path_option,
+    limit: int = typer.Option(None, help="Limit number of queries to cluster"),
 ):
     """Run HDBSCAN clustering."""
     model, provider = parse_embedding_model(embedding_model)
@@ -83,7 +86,7 @@ def cluster_hdbscan(
     chroma = create_chroma_client(chroma_path, model, provider) if use_chroma else None
     
     console.print(
-        f"[cyan]Running clustering: algo=hdbscan, model={model}, provider={provider}, use_chroma={use_chroma}[/cyan]"
+        f"[cyan]Running clustering: algo=hdbscan, model={model}, provider={provider}, use_chroma={use_chroma}, limit={limit}[/cyan]"
     )
     
     run_id = run_hdbscan_clustering(
@@ -98,6 +101,7 @@ def cluster_hdbscan(
         cluster_selection_epsilon=epsilon,
         metric=metric,
         chroma=chroma,
+        max_queries=limit,
     )
     
     if run_id:


### PR DESCRIPTION
Adds a new --limit flag for both clustering commands to cap how many queries are clustered. Enforces cap and records it in run parameters. Updates docs with usage examples.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `--limit` flag to KMeans and HDBSCAN clustering commands to cap query processing and update documentation with examples.
> 
>   - **Behavior**:
>     - Adds `--limit` flag to `cluster_kmeans` and `cluster_hdbscan` in `clustering.py` to cap query processing.
>     - Enforces query cap in `run_kmeans_clustering` and `run_hdbscan_clustering` by limiting processed queries.
>     - Records `limit` in run parameters in `kmeans.py` and `hdbscan_clustering.py`.
>   - **Documentation**:
>     - Updates `clustering.md` with `--limit` option and usage examples for both KMeans and HDBSCAN.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jxnl%2Flmsys-query-analysis&utm_source=github&utm_medium=referral)<sup> for ba3d8b61afa482c00d89aa068e93ce56211a1ba0. You can [customize](https://app.ellipsis.dev/jxnl/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->